### PR TITLE
adding test to demonstrate the behaviour when master thread is blocke…

### DIFF
--- a/src/clustering.test.ts
+++ b/src/clustering.test.ts
@@ -18,6 +18,7 @@ const cpusCmd = getPath('cpus')
 const masterCmd = getPath('master')
 const asyncMasterCmd = getPath('async-master')
 const asyncMasterArgumentsCmd = getPath('async-master-arguments')
+const asyncMasterArgumentsBlockedCmd = getPath('async-master-arguments-blocked')
 const asyncMasterFailureCmd = getPath('async-master-fail')
 const asyncMasterSyncFailureCmd = getPath('async-master-fail-sync')
 const asyncWorkerFailureCmd = getPath('async-worker-fail')
@@ -182,6 +183,16 @@ worker
  INFO Starting 2 workers
 worker { test: 1, test2: [ 'val' ] }
 worker { test: 1, test2: [ 'val' ] }
+`)
+    })
+
+    it('supplies undefined masterArgs to workers if master is unavailable', async () => {
+        const result = await run(asyncMasterArgumentsBlockedCmd, {})
+
+        expect(result.stdout).toBe(`master
+ INFO Starting 1 workers
+ WARN No response from master process for master arguments before timeout
+worker undefined
 `)
     })
 

--- a/src/fixtures/async-master-arguments-blocked.ts
+++ b/src/fixtures/async-master-arguments-blocked.ts
@@ -1,0 +1,33 @@
+import { gru } from '..'
+import { consoleLogger } from 'typescript-log'
+
+interface Args {
+    test: number
+    test2: string[]
+}
+gru<Args>({
+    logger: consoleLogger('debug'),
+    lifetime: 0,
+    workers: 1,
+    masterArgsWait: 1,
+    master: () =>
+        new Promise(resolve => setTimeout(resolve, 1)).then<Args>(() => {
+            setTimeout(() => {
+                const end = Date.now() + 100
+                while (Date.now() < end) {
+                    // @ts-ignore
+                    const blocking = 1 + 2 + 3
+                }
+            })
+
+            // eslint-disable-next-line no-console
+            console.log('master')
+
+            return { test: 1, test2: ['val'] }
+        }),
+    start: ({ masterArgs }) => {
+        // eslint-disable-next-line no-console
+        console.log('worker', masterArgs)
+        process.exit()
+    },
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ const DEFAULT_OPTIONS = {
     workers: cpuCount,
     lifetime: 'until-killed' as 'until-killed',
     grace: 5000,
+    masterArgsWait: 5000,
 }
 
 interface GetArgsMessage {
@@ -43,6 +44,8 @@ export interface Options<MasterArgs> {
      */
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     start: (args: { id: string; masterArgs: MasterArgs | undefined }) => Promise<any> | void
+    /** ms to wait for master to become available to supply masterArgs (default 5000) */
+    masterArgsWait?: number
 }
 
 let called = false
@@ -254,7 +257,7 @@ export async function gru<MasterArgs = undefined>(
                         'No response from master process for master arguments before timeout',
                     )
                     resolve(undefined)
-                }, 5000)
+                }, options.masterArgsWait)
 
                 // Setup response handler
                 process.once('message', (masterMsg: MasterMessages<MasterArgs>) => {


### PR DESCRIPTION
…d. Also made the time to wait for master configurable.

Saw this behaviour happen in a production environment due to a heavily loaded master thread. The workers receiving undefined for masterArgs was causing them to fail to start.

I'm unsure what additional fixes may be required (if any) but letting us turn up the time before giving up on the master thread would help.