### PR TITLE
Dedicated workers

### DIFF
--- a/src/fixtures/async-master-arguments.ts
+++ b/src/fixtures/async-master-arguments.ts
@@ -12,13 +12,13 @@ gru<Args>({
     master: () =>
         new Promise(resolve => setTimeout(resolve, 500)).then<Args>(() => {
             // eslint-disable-next-line no-console
-            console.log('master')
+            console.log('master output')
 
             return { test: 1, test2: ['val'] }
         }),
     start: ({ masterArgs }) => {
         // eslint-disable-next-line no-console
-        console.log('worker', masterArgs)
+        console.log('worker received', masterArgs)
         process.exit()
     },
 })

--- a/src/fixtures/dedicated-and-generic-workers.ts
+++ b/src/fixtures/dedicated-and-generic-workers.ts
@@ -1,0 +1,29 @@
+import { gru } from '..'
+import { consoleLogger } from 'typescript-log'
+
+const logger = consoleLogger('debug')
+gru({
+    logger,
+    lifetime: 0,
+    workers: 3,
+    master: () => {
+        // eslint-disable-next-line no-console
+        console.log('master output')
+    },
+    start: () => {
+        logger.info('generic worker output')
+        process.exit()
+    },
+    dedicatedWorkers: {
+        worker1: () => {
+            // eslint-disable-next-line no-console
+            console.log('worker1 output')
+            process.exit()
+        },
+        worker2: () => {
+            // eslint-disable-next-line no-console
+            console.log('worker2 output')
+            process.exit()
+        },
+    },
+})

--- a/src/fixtures/dedicated-and-inline-worker.ts
+++ b/src/fixtures/dedicated-and-inline-worker.ts
@@ -1,0 +1,29 @@
+import { gru } from '..'
+import { consoleLogger } from 'typescript-log'
+
+const logger = consoleLogger('debug')
+gru({
+    logger,
+    lifetime: 0,
+    workers: 0,
+    master: () => {
+        // eslint-disable-next-line no-console
+        console.log('master output')
+    },
+    start: () => {
+        logger.info('inline generic worker output')
+        // Don't call process.exit() in an inline worker as it runs within master
+    },
+    dedicatedWorkers: {
+        worker1: () => {
+            // eslint-disable-next-line no-console
+            console.log('worker1 output')
+            process.exit()
+        },
+        worker2: () => {
+            // eslint-disable-next-line no-console
+            console.log('worker2 output')
+            process.exit()
+        },
+    },
+})

--- a/src/fixtures/dedicated-workers.ts
+++ b/src/fixtures/dedicated-workers.ts
@@ -1,0 +1,26 @@
+import { gru } from '..'
+import { consoleLogger } from 'typescript-log'
+
+gru({
+    logger: consoleLogger('debug'),
+    lifetime: 0,
+    workers: 0,
+    master: () => {
+        // eslint-disable-next-line no-console
+        console.log('master output')
+    },
+    // eslint-disable-next-line
+    start: () => { },
+    dedicatedWorkers: {
+        worker1: () => {
+            // eslint-disable-next-line no-console
+            console.log('worker1 output')
+            process.exit()
+        },
+        worker2: () => {
+            // eslint-disable-next-line no-console
+            console.log('worker2 output')
+            process.exit()
+        },
+    },
+})

--- a/src/fixtures/graceful.ts
+++ b/src/fixtures/graceful.ts
@@ -6,7 +6,7 @@ gru({
     logger,
     workers: 3,
     start: () => {
-        logger.info('worker')
+        logger.info('worker output')
 
         process.on('SIGTERM', () => {
             logger.info('exiting worker')

--- a/src/fixtures/infinite.ts
+++ b/src/fixtures/infinite.ts
@@ -6,7 +6,7 @@ gru({
     workers: 3,
     start: () => {
         // eslint-disable-next-line no-console
-        console.log('worker')
+        console.log('worker output')
         process.exit()
     },
 })

--- a/src/fixtures/inline-worker.ts
+++ b/src/fixtures/inline-worker.ts
@@ -7,10 +7,10 @@ gru({
     workers: 0,
     master: () => {
         // eslint-disable-next-line no-console
-        console.log('master')
+        console.log('master output')
     },
     start: () => {
         // eslint-disable-next-line no-console
-        console.log('worker')
+        console.log('worker output')
     },
 })

--- a/src/worker-map.test.ts
+++ b/src/worker-map.test.ts
@@ -1,0 +1,15 @@
+import { getWorkerName, WorkerMap } from "./worker-map"
+
+const testWorkMap: WorkerMap = { 'worker 1': 7, 'worker 2': 15 }
+
+describe('getWorkerName()', () => {
+  it('finds an existing workers name', async () => {
+    const workerName = getWorkerName(7, testWorkMap)
+    expect(workerName).toEqual('worker 1')
+  })
+
+  it('returns null for a non-existant worker name', async () => {
+    const workerName = getWorkerName(4, testWorkMap)
+    expect(workerName).toBeNull()
+  })
+})

--- a/src/worker-map.ts
+++ b/src/worker-map.ts
@@ -1,0 +1,13 @@
+export type WorkerMap = { [workerName: string]: number }
+
+export function getWorkerName(workerId: number, workerMap: WorkerMap): string | null {
+  const workerNames = Object.keys(workerMap)
+
+  for (let i = 0; i < workerNames.length; i++) {
+    if (workerMap[workerNames[i]] === workerId) {
+      return workerNames[i]
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
This allows consumers to specify N dedicated worker threads in addition to a pool of generic workers.